### PR TITLE
Add support for HiDPI displays

### DIFF
--- a/compiled/app.js
+++ b/compiled/app.js
@@ -36535,13 +36535,17 @@ is expensive and ought to be cached.
 
 }).call(this);
 }, "util/canvas": function(exports, require, module) {(function() {
-  var canvasBounds, clear, drawGrid, drawLine, getSpacing, lerp, ticks;
+  var canvasBounds, clear, devicePixelRatio, drawGrid, drawLine, getSpacing, lerp, ticks;
 
   lerp = util.lerp;
+
+  devicePixelRatio = window.devicePixelRatio || 1;
 
   canvasBounds = function(ctx) {
     var canvas;
     canvas = ctx.canvas;
+    canvas.width *= devicePixelRatio;
+    canvas.height *= devicePixelRatio;
     return {
       cxMin: 0,
       cxMax: canvas.width,
@@ -36666,7 +36670,7 @@ is expensive and ought to be cached.
     drawLine(ctx, fromLocal([0, yMin]), fromLocal([0, yMax]));
     drawLine(ctx, fromLocal([xMin, 0]), fromLocal([xMax, 0]));
     labelEdgeDistance = labelDistance * 6;
-    ctx.font = "" + textHeight + "px verdana";
+    ctx.font = "" + (textHeight * devicePixelRatio) + "px verdana";
     ctx.fillStyle = labelColor;
     ctx.textAlign = "center";
     ctx.textBaseline = "top";
@@ -38759,12 +38763,13 @@ function HSLToRGB(h, s, l) {
       return this.programs = {};
     },
     sizeCanvas: function() {
-      var canvas, rect;
+      var canvas, devicePixelRatio, rect;
       canvas = this.getDOMNode();
       rect = canvas.getBoundingClientRect();
+      devicePixelRatio = window.devicePixelRatio || 1;
       if (canvas.width !== rect.width || canvas.height !== rect.height) {
-        canvas.width = rect.width;
-        return canvas.height = rect.height;
+        canvas.width = rect.width * devicePixelRatio;
+        return canvas.height = rect.height * devicePixelRatio;
       }
     },
     draw: function() {
@@ -38871,14 +38876,14 @@ function HSLToRGB(h, s, l) {
     var canvas, gl, h, sh, sw, sx, sy, w, x, y;
     gl = glod.gl();
     canvas = glod.canvas();
-    x = rect.left;
-    y = canvas.height - rect.bottom;
-    w = rect.width;
-    h = rect.height;
-    sx = clippingRect.left;
-    sy = canvas.height - clippingRect.bottom;
-    sw = clippingRect.width;
-    sh = clippingRect.height;
+    x = rect.left * devicePixelRatio;
+    y = canvas.height - rect.bottom * devicePixelRatio;
+    w = rect.width * devicePixelRatio;
+    h = rect.height * devicePixelRatio;
+    sx = clippingRect.left * devicePixelRatio;
+    sy = canvas.height - clippingRect.bottom * devicePixelRatio;
+    sw = clippingRect.width * devicePixelRatio;
+    sh = clippingRect.height * devicePixelRatio;
     gl.viewport(x, y, w, h);
     gl.scissor(sx, sy, sw, sh);
     return glod.viewport_ = {

--- a/src/util/canvas.coffee
+++ b/src/util/canvas.coffee
@@ -1,9 +1,12 @@
 
 lerp = util.lerp
 
+devicePixelRatio = window.devicePixelRatio || 1 # Scale canvas for HiDPI displays
 
 canvasBounds = (ctx) ->
   canvas = ctx.canvas
+  canvas.width *= devicePixelRatio
+  canvas.height *= devicePixelRatio
   {
     cxMin: 0
     cxMax: canvas.width
@@ -121,7 +124,7 @@ drawGrid = (ctx, opts) ->
 
   # draw labels
   labelEdgeDistance = labelDistance * 6 # To keep it from overlapping the axis labels
-  ctx.font = "#{textHeight}px verdana"
+  ctx.font = "#{textHeight * devicePixelRatio}px verdana" # Scale font size for HiDPI displays
   ctx.fillStyle = labelColor
   ctx.textAlign = "center"
   ctx.textBaseline = "top"

--- a/src/view/ShaderOverlayView.coffee
+++ b/src/view/ShaderOverlayView.coffee
@@ -20,9 +20,10 @@ R.create "ShaderOverlayView",
   sizeCanvas: ->
     canvas = @getDOMNode()
     rect = canvas.getBoundingClientRect()
+    devicePixelRatio = window.devicePixelRatio || 1 # Scale canvas for HiDPI displays
     if canvas.width != rect.width or canvas.height != rect.height
-      canvas.width = rect.width
-      canvas.height = rect.height
+      canvas.width = rect.width * devicePixelRatio
+      canvas.height = rect.height * devicePixelRatio
 
   draw: ->
     canvas = @getDOMNode()
@@ -129,15 +130,16 @@ setViewport = (glod, rect, clippingRect) ->
   gl = glod.gl()
   canvas = glod.canvas()
 
-  x = rect.left
-  y = canvas.height - rect.bottom
-  w = rect.width
-  h = rect.height
+  # Scale everything by devicePixelRatio for HiDPI displays
+  x = rect.left * devicePixelRatio
+  y = canvas.height - rect.bottom * devicePixelRatio
+  w = rect.width * devicePixelRatio
+  h = rect.height * devicePixelRatio
 
-  sx = clippingRect.left
-  sy = canvas.height - clippingRect.bottom
-  sw = clippingRect.width
-  sh = clippingRect.height
+  sx = clippingRect.left * devicePixelRatio
+  sy = canvas.height - clippingRect.bottom * devicePixelRatio
+  sw = clippingRect.width * devicePixelRatio
+  sh = clippingRect.height * devicePixelRatio
 
   gl.viewport(x, y, w, h)
   gl.scissor(sx, sy, sw, sh)


### PR DESCRIPTION
By scaling the canvas width/height by window.devicePixelRatio (or 1 for a fallback) we can enable HiDPI support.

Optionally, we can also scale the line width on line 13 in ShaderOverlayView.coffee, but IMO it isn't needed.

Before & After example:

![Shadershop before and after HiDPI support](https://cloud.githubusercontent.com/assets/1525809/5267464/1b978370-7a49-11e4-9b20-669cbf51f8bb.png)
